### PR TITLE
Исправление смысловых ошибок

### DIFF
--- a/Reforged/ru_RU.lang
+++ b/Reforged/ru_RU.lang
@@ -5777,7 +5777,7 @@ applyperish.heard=%s услышал Губительную песню!
 applyperish.already=%s уже слышал песню!
 
 playerparticipant.enough=Хватит, %s!
-playerparticipant.withdrew=%s снял %s!
+playerparticipant.withdrew=%s спраятал %s!
 playerparticipant.go=Давай, %s!
 playerparticipant.load=Не могу загрузить Атаки покемонов!
 
@@ -7698,5 +7698,5 @@ pokerus.message.inform1=Ваш Покемон, кажется, был зараж
 pokerus.message.inform2=ПокеВирус распространяется очень быстро, но, похоже, он не наносит никакого вреда.
 pokerus.message.inform3=Иногда он даже оказался полезным для роста Покемона, хотя инфекции, похоже, недолговечны.
 
-generator.ultra_space=Ультра Космос
+generator.ultra_space=Ультра Пространство
 generator.ultra_space.info=Нет тумана, нормальная гравитация. Пустота убивает!


### PR DESCRIPTION
1. Покемона не снимают, а убирают, прячут в Покебол.
2. Здесь по сложнее. Если просто переводить в переводчиках, то всё верно. Но смысл кроется в деталях. Space - также переводится как "пространство". А в данном случае, через портал, игрок попадает в Ultra Space - Ультра пространство (ну или как это переведено в аниме - Ультраизмерение).